### PR TITLE
Order file upload fixes for PR#1588

### DIFF
--- a/InvenTree/common/forms.py
+++ b/InvenTree/common/forms.py
@@ -27,7 +27,7 @@ class SettingEditForm(HelperForm):
         ]
 
 
-class UploadFile(forms.Form):
+class UploadFileForm(forms.Form):
     """ Step 1 of FileManagementFormView """
 
     file = forms.FileField(
@@ -65,7 +65,7 @@ class UploadFile(forms.Form):
         return file
 
 
-class MatchField(forms.Form):
+class MatchFieldForm(forms.Form):
     """ Step 2 of FileManagementFormView """
 
     def __init__(self, *args, **kwargs):
@@ -98,7 +98,7 @@ class MatchField(forms.Form):
                 self.fields[field_name].initial = col['guess']
 
 
-class MatchItem(forms.Form):
+class MatchItemForm(forms.Form):
     """ Step 3 of FileManagementFormView """
 
     def __init__(self, *args, **kwargs):
@@ -179,5 +179,6 @@ class MatchItem(forms.Form):
                         )
 
     def get_special_field(self, col_guess, row, file_manager):
-        """ function to be overriden in inherited forms to add specific form settings """
+        """ Function to be overriden in inherited forms to add specific form settings """
+
         return None

--- a/InvenTree/common/views.py
+++ b/InvenTree/common/views.py
@@ -118,7 +118,6 @@ class MultiStepFormView(SessionWizardView):
         form_steps_description: description for each form
     """
 
-    form_list = []
     form_steps_template = []
     form_steps_description = []
     file_manager = None
@@ -176,11 +175,11 @@ class FileManagementFormView(MultiStepFormView):
     """
 
     name = None
-    forms = {
-        'upload': forms.UploadFile,
-        'fields': forms.MatchField,
-        'items': forms.MatchItem,
-    }
+    form_list = [
+        ('upload', forms.UploadFileForm),
+        ('fields', forms.MatchFieldForm),
+        ('items', forms.MatchItemForm),
+    ]
     form_steps_description = [
         _("Upload File"),
         _("Match Fields"),
@@ -190,30 +189,18 @@ class FileManagementFormView(MultiStepFormView):
     extra_context_data = {}
 
     def __init__(self, *args, **kwargs):
-        """ initialize the FormView
-        Use the following syntax to override the forms that should be used in the steps:
+        """ Initialize the FormView """
 
-        def __init__(self, *args, **kwargs):
-            self.forms['items'] = self.CustomMatchItem
-            return super().__init__(*args, **kwargs)
-        """
-        # Construct form_list
-        self.form_list = [(key, value) for key, value in self.forms.items()]
-
-        # perform all checks and inits for MultiStepFormView
+        # Perform all checks and inits for MultiStepFormView
         super().__init__(self, *args, **kwargs)
 
         # Check for file manager class
         if not hasattr(self, 'file_manager_class') and not issubclass(self.file_manager_class, FileManager):
             raise NotImplementedError('A subclass of a file manager class needs to be set!')
 
-    @classmethod
-    def get_initkwargs(cls, *args, **kwargs):
-        # Construct form_list
-        kwargs['form_list'] = [(key, value) for key, value in cls.forms.items()]
-        return super().get_initkwargs(*args, **kwargs)
-
     def get_context_data(self, form=None, **kwargs):
+        """ Handle context data """
+
         if form is None:
             form = self.get_form()
 
@@ -412,6 +399,7 @@ class FileManagementFormView(MultiStepFormView):
                     'data': data,
                     'errors': {},
                 }
+
                 self.rows.append(row)
 
         # In the item selection step: update row data with mapping to form fields

--- a/InvenTree/order/forms.py
+++ b/InvenTree/order/forms.py
@@ -10,9 +10,16 @@ from django.utils.translation import ugettext_lazy as _
 
 from mptt.fields import TreeNodeChoiceField
 
+from djmoney.forms.fields import MoneyField
+
 from InvenTree.forms import HelperForm
 from InvenTree.fields import RoundingDecimalFormField
 from InvenTree.fields import DatePickerFormField
+
+from InvenTree.helpers import clean_decimal
+
+from common.models import InvenTreeSetting
+from common.forms import MatchItemForm
 
 import part.models
 
@@ -285,3 +292,37 @@ class EditSalesOrderAllocationForm(HelperForm):
             'line',
             'item',
             'quantity']
+
+
+class OrderMatchItemForm(MatchItemForm):
+    """ Override MatchItemForm fields """
+
+    def get_special_field(self, col_guess, row, file_manager):
+        """ Set special fields """
+
+        # set quantity field
+        if 'quantity' in col_guess.lower():
+            return forms.CharField(
+                required=False,
+                widget=forms.NumberInput(attrs={
+                    'name': 'quantity' + str(row['index']),
+                    'class': 'numberinput',
+                    'type': 'number',
+                    'min': '0',
+                    'step': 'any',
+                    'value': clean_decimal(row.get('quantity', '')),
+                })
+            )
+        # set price field
+        elif 'price' in col_guess.lower():
+            return MoneyField(
+                label=_(col_guess),
+                default_currency=InvenTreeSetting.get_setting('INVENTREE_DEFAULT_CURRENCY'),
+                decimal_places=5,
+                max_digits=19,
+                required=False,
+                default_amount=clean_decimal(row.get('purchase_price', '')),
+            )
+
+        # return default
+        return super().get_special_field(col_guess, row, file_manager)


### PR DESCRIPTION
* Revert back to form_list
* Moved OrderMatchItemForm to forms.py

Implementing `forms` dictionary is trickier than I thought so I don't think we should use that strategy. I think it is fine to override `form_list` completely, instead of trying to override only one item, that way it is straightforward and compatible implementation.