### PR TITLE
set write permission on specific job

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,6 +16,8 @@ jobs:
   backport:
     name: Backport PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: |
       github.event.pull_request.merged == true
       && contains(github.event.pull_request.labels.*.name, 'backport')


### PR DESCRIPTION
This reduces the likelihood of implicit write permissions for jobs where it is not intended