### PR TITLE
Revert "Granular flags"

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,36 +1,8 @@
-flags:
-  apps:
-    paths:
-      - src/backend/InvenTree/build
-      - src/backend/InvenTree/company
-      - src/backend/InvenTree/data_exporter
-      - src/backend/InvenTree/importer
-      - src/backend/InvenTree/machine
-      - src/backend/InvenTree/order
-      - src/backend/InvenTree/part
-      - src/backend/InvenTree/plugin
-      - src/backend/InvenTree/report
-      - src/backend/InvenTree/stock
-      - src/backend/InvenTree/users
-      - src/backend/InvenTree/web
-  general:
-    paths:
-      - src/backend/InvenTree/generic
-      - src/backend/InvenTree/common
-
 coverage:
   status:
     project:
       default:
         target: 82%
-      apps:
-        flags:
-          - apps
-        target: 90%
-      general:
-        flags:
-          - general
-        target: 95%
     patch: off
 
 github_checks:

--- a/contrib/container/requirements.in
+++ b/contrib/container/requirements.in
@@ -1,5 +1,4 @@
 # Base python requirements for docker containers
--c ../../src/backend/requirements.txt
 
 # Basic package requirements
 invoke>=2.2.0                   # Invoke build tool

--- a/contrib/container/requirements.txt
+++ b/contrib/container/requirements.txt
@@ -3,14 +3,11 @@
 asgiref==3.8.1 \
     --hash=sha256:3e1e3ecc849832fe52ccf2cb6686b7a55f82bb1d6aee72a58826471390335e47 \
     --hash=sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590
+    # via django
+django==4.2.20 \
+    --hash=sha256:213381b6e4405f5c8703fffc29cd719efdf189dec60c67c04f76272b3dc845b9 \
+    --hash=sha256:92bac5b4432a64532abb73b2ac27203f485e40225d2640a7fbef2b62b876e789
     # via
-    #   -c contrib/container/../../src/backend/requirements.txt
-    #   django
-django==4.2.21 \
-    --hash=sha256:1d658c7bf5d31c7d0cac1cab58bc1f822df89255080fec81909256c30e6180b3 \
-    --hash=sha256:b54ac28d6aa964fc7c2f7335138a54d78980232011e0cd2231d04eed393dcb0d
-    # via
-    #   -c contrib/container/../../src/backend/requirements.txt
     #   -r contrib/container/requirements.in
     #   django-auth-ldap
 django-auth-ldap==5.1.0 \
@@ -20,9 +17,7 @@ django-auth-ldap==5.1.0 \
 gunicorn==23.0.0 \
     --hash=sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d \
     --hash=sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec
-    # via
-    #   -c contrib/container/../../src/backend/requirements.txt
-    #   -r contrib/container/requirements.in
+    # via -r contrib/container/requirements.in
 invoke==2.2.0 \
     --hash=sha256:6ea924cc53d4f78e3d98bc436b08069a03077e6f85ad1ddaa8a116d7dad15820 \
     --hash=sha256:ee6cbb101af1a859c7fe84f2a264c059020b0cb7fe3535f9424300ab568f6bd5
@@ -54,7 +49,6 @@ packaging==24.2 \
     --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759 \
     --hash=sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f
     # via
-    #   -c contrib/container/../../src/backend/requirements.txt
     #   gunicorn
     #   mariadb
 psycopg[binary, pool]==3.2.6 \
@@ -201,26 +195,19 @@ pyyaml==6.0.2 \
     --hash=sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba \
     --hash=sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12 \
     --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4
-    # via
-    #   -c contrib/container/../../src/backend/requirements.txt
-    #   -r contrib/container/requirements.in
-setuptools==80.3.1 \
-    --hash=sha256:31e2c58dbb67c99c289f51c16d899afedae292b978f8051efaf6262d8212f927 \
-    --hash=sha256:ea8e00d7992054c4c592aeb892f6ad51fe1b4d90cc6947cc45c45717c40ec537
-    # via
-    #   -c contrib/container/../../src/backend/requirements.txt
-    #   -r contrib/container/requirements.in
+    # via -r contrib/container/requirements.in
+setuptools==79.0.1 \
+    --hash=sha256:128ce7b8f33c3079fd1b067ecbb4051a66e8526e7b65f6cec075dfc650ddfa88 \
+    --hash=sha256:e147c0549f27767ba362f9da434eab9c5dc0045d5304feb602a0af001089fc51
+    # via -r contrib/container/requirements.in
 sqlparse==0.5.3 \
     --hash=sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272 \
     --hash=sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca
-    # via
-    #   -c contrib/container/../../src/backend/requirements.txt
-    #   django
+    # via django
 typing-extensions==4.12.2 \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8
     # via
-    #   -c contrib/container/../../src/backend/requirements.txt
     #   psycopg
     #   psycopg-pool
 uv==0.6.6 \

--- a/src/backend/InvenTree/InvenTree/api_version.py
+++ b/src/backend/InvenTree/InvenTree/api_version.py
@@ -1,15 +1,12 @@
 """InvenTree API version information."""
 
 # InvenTree API version
-INVENTREE_API_VERSION = 342
+INVENTREE_API_VERSION = 341
 
 """Increment this API version number whenever there is a significant change to the API that any clients need to know about."""
 
 
 INVENTREE_API_TEXT = """
-v342 -> 2025-05-09 : https://github.com/inventree/InvenTree/pull/9651
-    - Fix serializer to match Generate API for serial numbers
-
 v341 -> 2025-04-21 : https://github.com/inventree/InvenTree/pull/9547
     - Require pagination limit on list queries
 

--- a/src/backend/InvenTree/stock/serializers.py
+++ b/src/backend/InvenTree/stock/serializers.py
@@ -143,24 +143,20 @@ class GenerateSerialNumberSerializer(serializers.Serializer):
     Any of the provided write-only fields can be used for additional context.
 
     Note that in the case where multiple serial numbers are required,
-    the "serial_number" field will return a string with multiple serial numbers
-    separated by a comma.
+    the "serial" field will return a string with multiple serial numbers separated by a comma.
     """
 
     class Meta:
         """Metaclass options."""
 
-        fields = ['serial_number', 'part', 'quantity']
+        fields = ['serial', 'part', 'quantity']
 
-        read_only_fields = ['serial_number']
+        read_only_fields = ['serial']
 
         write_only_fields = ['part', 'quantity']
 
-    serial_number = serializers.CharField(
-        read_only=True,
-        allow_null=True,
-        help_text=_('Generated serial number'),
-        label=_('Serial Number'),
+    serial = serializers.CharField(
+        read_only=True, help_text=_('Generated serial number'), label=_('Serial Number')
     )
 
     part = serializers.PrimaryKeyRelatedField(

--- a/src/backend/requirements-dev.txt
+++ b/src/backend/requirements-dev.txt
@@ -293,9 +293,9 @@ distlib==0.3.9 \
     --hash=sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87 \
     --hash=sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403
     # via virtualenv
-django==4.2.21 \
-    --hash=sha256:1d658c7bf5d31c7d0cac1cab58bc1f822df89255080fec81909256c30e6180b3 \
-    --hash=sha256:b54ac28d6aa964fc7c2f7335138a54d78980232011e0cd2231d04eed393dcb0d
+django==4.2.20 \
+    --hash=sha256:213381b6e4405f5c8703fffc29cd719efdf189dec60c67c04f76272b3dc845b9 \
+    --hash=sha256:92bac5b4432a64532abb73b2ac27203f485e40225d2640a7fbef2b62b876e789
     # via
     #   -c src/backend/requirements.txt
     #   django-slowtests
@@ -341,9 +341,9 @@ pdfminer-six==20250416 \
     --hash=sha256:30956a85f9d0add806a4e460ed0d67c2b6a48b53323c7ac87de23174596d3acd \
     --hash=sha256:dd2a9ad7bc7dd6b62d009aaa9c101ac9d069a47937724569c375a6a9078da303
     # via -r src/backend/requirements-dev.in
-pip==25.1.1 \
-    --hash=sha256:2913a38a2abf4ea6b64ab507bd9e967f3b53dc1ede74b01b0931e1ce548751af \
-    --hash=sha256:3de45d411d308d5054c2168185d8da7f9a2cd753dbac8acbfa88a8909ecd9077
+pip==25.0.1 \
+    --hash=sha256:88f96547ea48b940a3a385494e181e29fb8637898f88d88737c5049780f196ea \
+    --hash=sha256:c46efd13b6aa8279f33f2864459c8ce587ea6a1a59ee20de055868d8f7688f7f
     # via pip-tools
 pip-tools==7.4.1 \
     --hash=sha256:4c690e5fbae2f21e87843e89c26191f0d9454f362d8acdbd695716493ec8b3a9 \
@@ -428,9 +428,9 @@ pyyaml==6.0.2 \
     # via
     #   -c src/backend/requirements.txt
     #   pre-commit
-setuptools==80.3.1 \
-    --hash=sha256:31e2c58dbb67c99c289f51c16d899afedae292b978f8051efaf6262d8212f927 \
-    --hash=sha256:ea8e00d7992054c4c592aeb892f6ad51fe1b4d90cc6947cc45c45717c40ec537
+setuptools==80.1.0 \
+    --hash=sha256:2e308396e1d83de287ada2c2fd6e64286008fe6aca5008e0b6a8cb0e2c86eedd \
+    --hash=sha256:ea0e7655c05b74819f82e76e11a85b31779fee7c4969e82f72bab0664e8317e4
     # via
     #   -c src/backend/requirements.txt
     #   -r src/backend/requirements-dev.in

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -390,9 +390,9 @@ deprecated==1.2.18 \
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-semantic-conventions
-django==4.2.21 \
-    --hash=sha256:1d658c7bf5d31c7d0cac1cab58bc1f822df89255080fec81909256c30e6180b3 \
-    --hash=sha256:b54ac28d6aa964fc7c2f7335138a54d78980232011e0cd2231d04eed393dcb0d
+django==4.2.20 \
+    --hash=sha256:213381b6e4405f5c8703fffc29cd719efdf189dec60c67c04f76272b3dc845b9 \
+    --hash=sha256:92bac5b4432a64532abb73b2ac27203f485e40225d2640a7fbef2b62b876e789
     # via
     #   -r src/backend/requirements.in
     #   django-allauth
@@ -1578,9 +1578,9 @@ sentry-sdk==2.27.0 \
     # via
     #   -r src/backend/requirements.in
     #   django-q-sentry
-setuptools==80.3.1 \
-    --hash=sha256:31e2c58dbb67c99c289f51c16d899afedae292b978f8051efaf6262d8212f927 \
-    --hash=sha256:ea8e00d7992054c4c592aeb892f6ad51fe1b4d90cc6947cc45c45717c40ec537
+setuptools==80.1.0 \
+    --hash=sha256:2e308396e1d83de287ada2c2fd6e64286008fe6aca5008e0b6a8cb0e2c86eedd \
+    --hash=sha256:ea0e7655c05b74819f82e76e11a85b31779fee7c4969e82f72bab0664e8317e4
     # via
     #   -r src/backend/requirements.in
     #   django-money


### PR DESCRIPTION
Reverts matmair/InvenTree#363

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Renamed the field in serial number generation output from "serial_number" to "serial" for consistency.
- **Chores**
  - Updated and simplified dependency requirements, including downgrading Django and setuptools versions.
  - Updated coverage configuration to remove flag-based targets and adjust thresholds.
  - Updated API versioning to reflect recent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->