### PR TITLE
🛡️ Sentinel: Fix XSS vulnerabilities in report template tags

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - XSS in Report Template Tags
+**Vulnerability:** XSS in `internal_link` and `render_html_text` report template tags due to use of `mark_safe` with unescaped user input.
+**Learning:** `mark_safe` should only be used on strings where you are absolutely sure the content is safe. When combining HTML templates with user input, `format_html` is much safer as it automatically escapes arguments.
+**Prevention:** Always use `format_html` instead of `mark_safe` with f-strings when generating HTML with dynamic content.

--- a/src/backend/InvenTree/report/templatetags/report.py
+++ b/src/backend/InvenTree/report/templatetags/report.py
@@ -981,7 +981,9 @@ def render_html_text(text: str, **kwargs):
 
     # Wrap the text in the requested tags
     for tag in reversed(tags):
-        output = format_html('<{tag}>{content}</{tag}>', tag=mark_safe(tag), content=output)
+        output = format_html(
+            '<{tag}>{content}</{tag}>', tag=mark_safe(tag), content=output
+        )
 
     return output
 

--- a/src/backend/InvenTree/report/templatetags/report.py
+++ b/src/backend/InvenTree/report/templatetags/report.py
@@ -19,6 +19,7 @@ from django.core.files.storage import default_storage
 from django.db.models import Model
 from django.db.models.query import QuerySet
 from django.utils import translation
+from django.utils.html import format_html
 from django.utils.safestring import SafeString, mark_safe
 from django.utils.translation import gettext_lazy as _
 
@@ -615,7 +616,7 @@ def internal_link(link, text) -> str:
         logger.warning('Failed to construct absolute URL for internal link')
         return text
 
-    return mark_safe(f'<a href="{url}">{text}</a>')
+    return format_html('<a href="{url}">{text}</a>', url=url, text=text)
 
 
 def make_decimal(value: Any) -> Any:
@@ -973,13 +974,16 @@ def render_html_text(text: str, **kwargs):
         tags.append('em')
 
     if heading := kwargs.get('heading', ''):
-        tags.append(heading)
+        if heading in ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div', 'span']:
+            tags.append(heading)
 
-    output = ''.join([f'<{tag}>' for tag in tags])
-    output += text
-    output += ''.join([f'</{tag}>' for tag in tags])
+    output = text
 
-    return mark_safe(output)
+    # Wrap the text in the requested tags
+    for tag in reversed(tags):
+        output = format_html('<{tag}>{content}</{tag}>', tag=mark_safe(tag), content=output)
+
+    return output
 
 
 @register.simple_tag
@@ -1149,8 +1153,11 @@ def icon(name, **kwargs):
         return ''
 
     unicode = chr(int(icon['variants'][variant], 16))
-    return mark_safe(
-        f'<i class="icon {kwargs.get("class", "")}" style="font-family: inventree-icon-font-{pack.prefix}">{unicode}</i>'
+    return format_html(
+        '<i class="icon {cls}" style="font-family: inventree-icon-font-{prefix}">{unicode}</i>',
+        cls=kwargs.get('class', ''),
+        prefix=pack.prefix,
+        unicode=unicode,
     )
 
 


### PR DESCRIPTION
Fixed several XSS vulnerabilities in the report template tags by replacing `mark_safe` with `format_html` and adding a whitelist for heading tags.

---
*PR created automatically by Jules for task [1533195545968888754](https://jules.google.com/task/1533195545968888754) started by @matmair*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety when rendering links, icons, and formatted text in reports.
  * Fixed a potential cross-site scripting issue by escaping dynamic content more reliably.
  * Added stricter validation for heading formatting to prevent unsafe HTML output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->